### PR TITLE
Fix DOIs in publication data file

### DIFF
--- a/_scripts/gen_refs_yml.py
+++ b/_scripts/gen_refs_yml.py
@@ -28,6 +28,8 @@ def format_note(match):
 subst = {
         '---\n': '',
         '\n---': '',
+        r'\\\\\\\\\\\\\_': '_', # remove 6 \ before _
+        r'\\\\\\\_': '_', # remove 3 \ before _
         'nocite: \"\[@\*\]\"\n': '',
         r'issued: ([0-9][0-9][0-9][0-9])-([0-9][0-9])':\
                 r'issued:\n  - year: \1\n    month: \2',


### PR DESCRIPTION
In .bib files the underscores in DOIs are usually escaped ('\_'). When converting biblatex to YAML, pandoc escapes both characters again.  This results in '\\\_'.  When writing the DOI url, this is repeated to produced '\\\\\\_'.

I couldn't find a way to turn this of.  Instead this commit extends the generation python script to remove those superfluous escapes.