### PR TITLE
Update newsletter sign up

### DIFF
--- a/newsletter.md
+++ b/newsletter.md
@@ -5,29 +5,4 @@ title: Newsletter
 
 # Newsletter
 
-Get cvc5's updates, no more than once a month. We respect your inbox! Sign up below to receive our newletter, which will include links to the most recent blog post and information about new features and releases.
-
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-
-<style>
-  .responsive-iframe {
-    overflow: hidden;
-    padding-top: 100%;
-    position: relative;
-    height: 0;
-  }
-
-  .responsive-iframe iframe {
-    border: 0;
-    height: 100%;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
-  }
-</style>
-
-<div class="responsive-iframe">
-  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLSePwHdra_XvP21gwrI3Frtbt-NCpKjol4Lcwu3RSwteE76how/viewform?embedded=true" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
-</div>
+Get cvc5's updates, no more than once a month. We respect your inbox! Join our <a href="https://groups.google.com/g/cvc5-newsletter" class="button">cvc5-newsletter Google Group</a> to get the latest newsletter delivered to your inbox. Although we use Google Groups to send out our newsletter, members cannot post to the group. The only posts/emails will be the newsletter. Questions about newsletter content can be posted on our <a href="https://github.com/cvc5/cvc5/discussions" class="button">GitHub Discussions</a>.


### PR DESCRIPTION
Instead of using a google form for newsletter signup, we are now using google groups. The google group allows only the cvc5 solver email address to post to the group, so it remains a one-way communication channel. Questions will be directed to github discussions. 